### PR TITLE
feat: add `pnp search` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,8 +685,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +641,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "colored",
  "dirs",
  "filetime",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +632,7 @@ dependencies = [
  "clap",
  "dirs",
  "filetime",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -665,6 +675,23 @@ dependencies = [
  "getrandom",
  "redox_syscall",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 regex = "1.5"
 dirs = "4.0.0"
+colored = "2"
 serde_json = "1.0.79"
 chrono = "0.4.19"
 filetime = "0.2.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-regex = "1.5"
 dirs = "4.0.0"
 colored = "2"
 serde_json = "1.0.79"
 chrono = "0.4.19"
 filetime = "0.2.15"
 anyhow = "1.0.55"
+regex = { version = "1.5", default-features = false, features = ["std"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "3.1.1", features = ["cargo"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+regex = "1.5"
 dirs = "4.0.0"
 serde_json = "1.0.79"
 chrono = "0.4.19"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub fn build() -> Command<'static> {
                 .arg(arg!([name] "Plugin name")),
             Command::new("search")
                 .about("Search through plugin database")
-                .arg(arg!(--author "Filter by plugin author"))
+                .arg(arg!(--author <name> "Filter by plugin author").required(false).takes_value(true))
                 .arg(arg!(<request> "Part of GitHub's author/name").multiple_values(true)),
         ])
 }
@@ -42,8 +42,13 @@ pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
     match &matches.subcommand() {
         Some(("init", sub_matches)) => handle::init(sub_matches.is_present("plugin"))?,
         Some(("search", sub_matches)) => {
+            let mut author = String::new();
+            let should_filter_by_author = sub_matches.is_present("author");
             let params: Vec<&str> = sub_matches.values_of("request").unwrap().collect();
-            handle::search(sub_matches.is_present("author"), params)?
+            if should_filter_by_author {
+                author = sub_matches.values_of("author").unwrap().collect();
+            }
+            handle::search(should_filter_by_author, &author, params)?
         },
         _ => (),
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub fn build() -> Command<'static> {
             Command::new("search")
                 .about("Search through plugin database")
                 .arg(arg!(--author <name> "Filter by plugin author").required(false).takes_value(true))
-                .arg(arg!(<request> "Part of GitHub's author/name").multiple_values(true)),
+                .arg(arg!(<request> "Part of GitHub's author/name").required(false).multiple_values(true)),
         ])
 }
 
@@ -44,7 +44,10 @@ pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
         Some(("search", sub_matches)) => {
             let mut author = String::new();
             let should_filter_by_author = sub_matches.is_present("author");
-            let params: Vec<&str> = sub_matches.values_of("request").unwrap().collect();
+            let mut params: Vec<&str> = Vec::new();
+            if sub_matches.is_present("request") {
+                params = sub_matches.values_of("request").unwrap().collect();
+            }
             if should_filter_by_author {
                 author = sub_matches.values_of("author").unwrap().collect();
             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::handle;
-use crate::manager;
+use crate::database;
 use clap::{arg, command, Command};
 
 /// Generate clap cli command
@@ -26,6 +26,7 @@ pub fn build() -> Command<'static> {
                 .arg(arg!([name] "Plugin name")),
             Command::new("search")
                 .about("Search through plugin database")
+                .arg(arg!(--author "Filter by plugin author"))
                 .arg(arg!(<request> "Part of GitHub's author/name")),
         ])
 }
@@ -33,13 +34,14 @@ pub fn build() -> Command<'static> {
 /// Handle clap cli matches
 pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
     if !&matches.is_present("freeze") {
-        let outdated = manager::is_outdated().await?;
+        let outdated = database::is_outdated().await?;
         if outdated {
-            manager::load_database().await?;
+            database::load_database().await?;
         }
     }
     match &matches.subcommand() {
         Some(("init", sub_matches)) => handle::init(sub_matches.is_present("plugin"))?,
+        Some(("search", sub_matches)) => handle::search(sub_matches.is_present("author"))?,
         _ => (),
     }
     Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub fn build() -> Command<'static> {
             Command::new("search")
                 .about("Search through plugin database")
                 .arg(arg!(--author "Filter by plugin author"))
-                .arg(arg!(<request> "Part of GitHub's author/name")),
+                .arg(arg!(<request> "Part of GitHub's author/name").multiple_values(true)),
         ])
 }
 
@@ -41,7 +41,10 @@ pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
     }
     match &matches.subcommand() {
         Some(("init", sub_matches)) => handle::init(sub_matches.is_present("plugin"))?,
-        Some(("search", sub_matches)) => handle::search(sub_matches.is_present("author"))?,
+        Some(("search", sub_matches)) => {
+            let params: Vec<&str> = sub_matches.values_of("request").unwrap().collect();
+            handle::search(sub_matches.is_present("author"), params)?
+        },
         _ => (),
     }
     Ok(())

--- a/src/database.rs
+++ b/src/database.rs
@@ -70,3 +70,13 @@ pub async fn load_database() -> anyhow::Result<()> {
 pub async fn is_outdated() -> anyhow::Result<bool> {
     Ok(fetch_remote_updatetime().await? > fetch_local_updatetime().await?)
 }
+
+/// Retrieve local database path
+pub fn get_database_path() -> anyhow::Result<String> {
+    let path = format!(
+        "{}/{}",
+        dirs::data_dir().unwrap().to_str().unwrap(),
+        "pnp/database.json"
+    );
+    Ok(path)
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -49,10 +49,10 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
             let author_and_sep = author.to_owned() + "/";
             if filter_by_author {
                 if author == author_name {
-                    println!("{}{}\n    {}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+                    println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
                 }
             } else {
-                println!("{}{}\n    {}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+                println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
             }
         }
     }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -44,8 +44,8 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
     for (plugin, metadata) in database_json.iter() {
         let author = metadata["owner"]["login"].as_str().unwrap();
         let description = metadata["description"].as_str().unwrap_or("No description available");
-        let matches: Vec<_> = search_params.matches(description).into_iter().collect();
-        if matches.len() == params.len() {
+        let matches = search_params.matches(description);
+        if matches.into_iter().count() == params.len() {
             let author_and_sep = author.to_owned() + "/";
             if filter_by_author {
                 if author == author_name {

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,5 +1,10 @@
 use std::fs::File;
-use std::io::Write;
+use std::io::{Write, BufReader};
+use std::collections::HashMap;
+use serde_json::{Value, from_reader};
+use regex::Regex;
+
+use crate::database;
 
 const PLUGIN_CONTENT: &str = include_str!("../templates/plugin.json");
 const CONFIG_CONTENT: &str = include_str!("../templates/cfg.jsonc");
@@ -13,5 +18,34 @@ pub fn init(toggle: bool) -> anyhow::Result<()> {
         let mut output = File::create("./cfg.jsonc")?;
         write!(output, "{CONFIG_CONTENT}")?;
     }
+    Ok(())
+}
+
+/// `pnp search` logic
+pub fn search(_filter_by_author: bool) -> anyhow::Result<()> {
+    // Custom HashMap type so we can iterate over our database
+    type JsonMap = HashMap<String, Value>;
+
+    // TODO: make the filter_by_author logic
+    //
+    // Get the database path and open database if exists
+    let pnp_database = match database::get_database_path() {
+        Ok(database) => File::open(database)?,
+        Err(e) => {
+            panic!("{e:?}");
+        }
+    };
+    // Read database contents and convert it to a string
+    let buf_reader = BufReader::new(pnp_database);
+    // Deserialize JSON database from reader
+    let database_json: JsonMap = from_reader(buf_reader)?;
+    for (plugin, metadata) in database_json.iter() {
+        let description = match metadata["description"].as_str() {
+            Some(desc) => desc,
+            None => "No description available",
+        };
+        println!("plugin : {:?}\ndescription : {:?}", plugin, description);
+    }
+
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 mod handle;
-mod manager;
+mod database;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
Implement search command, takes two optional arguments and can be used in four different ways:

1. `pnp search`: searches all available plugins.
2. `pnp search --author=NTBBloodbath`: searches all plugins from NTBBloodbath.
3. `pnp search --author=NTBBloodbath doom`: searches all plugins from NTBBloodbath that contains `doom` .word.
4. `pnp search colorscheme lua`: searches all plugins that contains `colorscheme` and `lua` words.

Optional arguments:
- `--author=name | --author name`: filter plugins search by author.
- `request`: the search keywords, e.g. `colorscheme`.