### PR TITLE
feat(search): allow to filter by plugin name, e.g. `pnp search onedark.nvim`

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -7,7 +7,6 @@ use regex::RegexSet;
 use colored::*;
 
 use crate::database;
-use std::io::prelude::*;
 
 const PLUGIN_CONTENT: &str = include_str!("../templates/plugin.json");
 const CONFIG_CONTENT: &str = include_str!("../templates/cfg.jsonc");
@@ -45,10 +44,12 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
     let search_params = RegexSet::new(&params)?;
     for (plugin, metadata) in database_json.iter() {
         let author = metadata["owner"]["login"].as_str().unwrap();
+        let author_and_sep = author.to_owned() + "/";
         let description = metadata["description"].as_str().unwrap_or("No description available");
-        let matches = search_params.matches(description);
-        if matches.into_iter().count() == params.len() {
-            let author_and_sep = author.to_owned() + "/";
+
+        let desc_matches = search_params.matches(description);
+        let name_matches = search_params.matches(plugin);
+        if desc_matches.into_iter().count() == params.len() {
             if filter_by_author {
                 if author == author_name {
                     println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
@@ -56,6 +57,10 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
             } else {
                 println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
             }
+        } else if name_matches.into_iter().count() == params.len() {
+            println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+        } else if params[0] == plugin {
+            println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
         }
     }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -57,9 +57,7 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
             } else {
                 println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
             }
-        } else if name_matches.into_iter().count() == params.len() {
-            println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
-        } else if params[0] == plugin {
+        } else if name_matches.into_iter().count() == params.len() || params[0] == plugin {
             println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
         }
     }


### PR DESCRIPTION
This PR allows to filter by plugin name when using search command. Here's a preview.

![image](https://user-images.githubusercontent.com/36456999/155894593-1078dce1-9c20-48d4-8ae8-e30aa0d7bd11.png)
