### PR TITLE
feat: add `pnp info` command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,10 @@ pub fn build() -> Command<'static> {
             Command::new("search")
                 .about("Search through plugin database")
                 .arg(arg!(--author <name> "Filter by plugin author").required(false).takes_value(true))
-                .arg(arg!(<request> "Part of GitHub's author/name").required(false).multiple_values(true)),
+                .arg(arg!([request] "Part of GitHub's author/name").multiple_values(true)),
+            Command::new("info")
+                .about("Show information about a specific plugin")
+                .arg(arg!(<name> "Plugin name")),
         ])
 }
 
@@ -47,6 +50,7 @@ pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
             }
             handle::search(should_filter_by_author, &author, params)?
         },
+        Some(("info", sub_matches)) => handle::info(sub_matches.value_of("name").unwrap())?,
         Some(("install", _)) => handle::install().await?,
         // TODO: optional `name` arg
         Some(("update", sub_matches)) => handle::update(sub_matches.value_of("name")).await?,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,10 +25,7 @@ pub fn build() -> Command<'static> {
                         .required(false)
                         .takes_value(true),
                 )
-                .arg(
-                    arg!([request] "Part of GitHub's author/name")
-                        .multiple_values(true),
-                ),
+                .arg(arg!([request] "Part of GitHub's author/name").multiple_values(true)),
             Command::new("info")
                 .about("Show information about a specific plugin")
                 .arg(arg!(<name> "Plugin name")),
@@ -56,7 +53,7 @@ pub async fn handle(matches: clap::ArgMatches) -> anyhow::Result<()> {
                 author = sub_matches.values_of("author").unwrap().collect();
             }
             handle::search(should_filter_by_author, &author, params)?
-        },
+        }
         Some(("info", sub_matches)) => handle::info(sub_matches.value_of("name").unwrap())?,
         Some(("install", _)) => handle::install().await?,
         // TODO: optional `name` arg

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,9 +1,9 @@
 use filetime::FileTime;
 use reqwest::Client;
-use std::io::BufReader;
-use std::fs::File;
-use std::collections::HashMap;
 use serde_json::{from_reader, Value};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
 
 const DATABASE_COMMITS_LINK: &str = "https://api.github.com/repos/nvim-plugnplay/database/commits?path=database.json&page=1&per_page=1";
 const DATABASE_RAW_LINK: &str =

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,10 +1,16 @@
 use filetime::FileTime;
 use reqwest::Client;
-use serde_json::Value;
+use std::io::BufReader;
+use std::fs::File;
+use std::collections::HashMap;
+use serde_json::{from_reader, Value};
 
 const DATABASE_COMMITS_LINK: &str = "https://api.github.com/repos/nvim-plugnplay/database/commits?path=database.json&page=1&per_page=1";
 const DATABASE_RAW_LINK: &str =
     "https://raw.githubusercontent.com/nvim-plugnplay/database/main/database.json";
+
+// Custom HashMap type so we can iterate over our database
+pub type JsonMap = HashMap<String, Value>;
 
 /// Get last modification time of database.json from remote source
 async fn fetch_remote_updatetime() -> anyhow::Result<i64> {
@@ -76,4 +82,20 @@ pub fn get_database_path() -> anyhow::Result<String> {
         "pnp/database.json"
     );
     Ok(path)
+}
+
+/// Get the local database contents
+pub fn read_database() -> anyhow::Result<JsonMap> {
+    // Get the database path and open database if exists
+    let pnp_database = match get_database_path() {
+        Ok(database) => File::open(database)?,
+        Err(e) => {
+            panic!("{e:?}");
+        }
+    };
+    // Read database contents and convert it to a string
+    let buf_reader = BufReader::new(pnp_database);
+    // Deserialize JSON database from reader
+    let database_json: JsonMap = from_reader(buf_reader)?;
+    Ok(database_json)
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -117,8 +117,8 @@ pub fn info(plugin_name: &str) -> anyhow::Result<()> {
         let repo = metadata["clone_url"].as_str().unwrap().replace(".git", "");
         let maintainer = metadata["owner"]["login"].as_str().unwrap();
         let description = metadata["description"].as_str().unwrap();
-        let stars_count = metadata["stargazers_count"].as_i64().unwrap();
-        let forks_count = metadata["forks_count"].as_i64().unwrap();
+        let stars_count = metadata["stargazers_count"].as_u64().unwrap();
+        let forks_count = metadata["forks_count"].as_u64().unwrap();
         let updated_date = metadata["updated_at"]
             .as_str()
             .unwrap()

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -80,17 +80,11 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
 
         let desc_matches = search_params.matches(description);
         let name_matches = search_params.matches(plugin);
-        if desc_matches.into_iter().count() == params.len() {
-            if filter_by_author {
-                if author == author_name {
-                    println!(
-                        "{}{}\n\t{}\n",
-                        author_and_sep.purple().bold(),
-                        plugin.bold(),
-                        description
-                    )
-                }
-            } else {
+        if (desc_matches.into_iter().count() == params.len())
+            || (name_matches.into_iter().count() == params.len())
+            || (params[0] == plugin)
+        {
+            if (!filter_by_author) || (filter_by_author && (author == author_name)) {
                 println!(
                     "{}{}\n\t{}\n",
                     author_and_sep.purple().bold(),
@@ -98,13 +92,6 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
                     description
                 )
             }
-        } else if name_matches.into_iter().count() == params.len() || params[0] == plugin {
-            println!(
-                "{}{}\n\t{}\n",
-                author_and_sep.purple().bold(),
-                plugin.bold(),
-                description
-            )
         }
     }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,8 +1,8 @@
 use crate::data::*;
+use colored::*;
+use regex::RegexSet;
 use std::fs::File;
 use std::io::Write;
-use regex::RegexSet;
-use colored::*;
 
 use crate::database::{self, JsonMap};
 
@@ -74,20 +74,37 @@ pub fn search(filter_by_author: bool, author_name: &str, params: Vec<&str>) -> a
     for (plugin, metadata) in database_json.iter() {
         let author = metadata["owner"]["login"].as_str().unwrap();
         let author_and_sep = author.to_owned() + "/";
-        let description = metadata["description"].as_str().unwrap_or("No description available");
+        let description = metadata["description"]
+            .as_str()
+            .unwrap_or("No description available");
 
         let desc_matches = search_params.matches(description);
         let name_matches = search_params.matches(plugin);
         if desc_matches.into_iter().count() == params.len() {
             if filter_by_author {
                 if author == author_name {
-                    println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+                    println!(
+                        "{}{}\n\t{}\n",
+                        author_and_sep.purple().bold(),
+                        plugin.bold(),
+                        description
+                    )
                 }
             } else {
-                println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+                println!(
+                    "{}{}\n\t{}\n",
+                    author_and_sep.purple().bold(),
+                    plugin.bold(),
+                    description
+                )
             }
         } else if name_matches.into_iter().count() == params.len() || params[0] == plugin {
-            println!("{}{}\n\t{}\n", author_and_sep.purple().bold(), plugin.bold(), description)
+            println!(
+                "{}{}\n\t{}\n",
+                author_and_sep.purple().bold(),
+                plugin.bold(),
+                description
+            )
         }
     }
 
@@ -110,10 +127,7 @@ pub fn info(plugin_name: &str) -> anyhow::Result<()> {
         // - topics
         // - license (missing field, remote database isn't updated with this field)
         // - size (missing field, not implemented yet)
-        let repo = metadata["clone_url"]
-            .as_str()
-            .unwrap()
-            .replace(".git", "");
+        let repo = metadata["clone_url"].as_str().unwrap().replace(".git", "");
         let maintainer = metadata["owner"]["login"].as_str().unwrap();
         let description = metadata["description"].as_str().unwrap();
         let stars_count = metadata["stargazers_count"].as_i64().unwrap();

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -3,11 +3,6 @@ use std::fs::File;
 use std::io::Write;
 use regex::RegexSet;
 use colored::*;
-use regex::RegexSet;
-use serde_json::{from_reader, Value};
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufReader, Write};
 
 use crate::database::{self, JsonMap};
 


### PR DESCRIPTION
This PR aims to add a new command called `info` that displays a more detailed information about the requested plugin, e.g. last update date, stars and forks count, etc.